### PR TITLE
Add repo option in __using__ macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ You should already have [Ecto](https://github.com/elixir-ecto/ecto) installed an
       repo: MyApp.Projections.Repo
     ```
 
+    Or alternatively in case of umbrella application define it later per projection:
+
+    ```elixir
+    defmodule MyApp.ExampleProjector do
+      use Commanded.Projections.Ecto,
+        name: "example_projection",
+        repo: MyApp.Projections.Repo
+
+      ...
+    end
+    ```
+
 3. Generate an Ecto migration in your app:
 
     ```console

--- a/lib/projections/ecto.ex
+++ b/lib/projections/ecto.ex
@@ -20,7 +20,9 @@ defmodule Commanded.Projections.Ecto do
   defmacro __using__(opts) do
     quote location: :keep do
       @opts unquote(opts) || []
-      @repo Application.get_env(:commanded_ecto_projections, :repo) || raise "Commanded Ecto projections expects :repo to be configured in environment"
+      @repo @opts[:repo] ||
+            Application.get_env(:commanded_ecto_projections, :repo) ||
+            raise "Commanded Ecto projections expects :repo to be configured in environment"
       @projection_name @opts[:name] || raise "#{inspect __MODULE__} expects :name to be given"
 
       use Ecto.Schema

--- a/test/projections/ecto_test.exs
+++ b/test/projections/ecto_test.exs
@@ -96,6 +96,24 @@ defmodule Commanded.Projections.EctoTest do
     end
   end
 
+  test "should allow to set :repo as an option" do
+    repo = Application.get_env(:commanded_ecto_projections, :repo)
+
+    try do
+      Application.put_env(:commanded_ecto_projections, :repo, nil)
+
+      assert Code.eval_string """
+      defmodule ProjectorConfiguredViaOpts do
+        use Commanded.Projections.Ecto,
+          name: "projector",
+          repo: Commanded.Projections.Repo
+      end
+      """
+    after
+      Application.put_env(:commanded_ecto_projections, :repo, repo)
+    end
+  end
+
   test "should ensure projection name is present" do
     assert_raise RuntimeError, "UnnamedProjector expects :name to be given", fn ->
       Code.eval_string """


### PR DESCRIPTION
It gives the ability to use this in umbrella which uses commanded in multiple apps.