### PR TITLE
Document skipping an event in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ defmodule MyApp.ExampleProjector do
 end
 ```
 
+If you want to skip a projection event, you can return the `multi` transation without further modifying it.
+
+```
+project %ItemUpdated{uuid: uuid} = event, _metadata do
+  case Repo.get(ItemProjection, uuid) do
+    nil -> multi
+    item -> Ecto.Multi.update(multi, :item, update_changeset(event, item))
+  end
+end
+```
+
 ### Supervision
 
 Your projector module must be included in your application supervision tree:


### PR DESCRIPTION
I was wondering a little how to skip a projection event after the clause has matched. 

One needs to return the `multi` unchanged to avoid the error exit if I'm not mistaken.

I thought it's worth mentioning.