### PR TITLE
Fix: Pass the `schema_prefix` to `Ecto.Multi.update`

### DIFF
--- a/priv/repo/migrations/20170929080308_create_projection_version_with_prefix.exs
+++ b/priv/repo/migrations/20170929080308_create_projection_version_with_prefix.exs
@@ -1,0 +1,20 @@
+defmodule Commanded.Projections.Repo.Migrations.CreateProjectionVersionWithPrefix do
+  use Ecto.Migration
+
+  def up do
+    execute "CREATE SCHEMA test"
+
+    create table(:projection_versions, primary_key: false, prefix: "test") do
+      add :projection_name, :text, primary_key: true
+      add :last_seen_event_number, :bigint
+
+      timestamps()
+    end
+  end
+
+  def down do
+    drop table(:projection_versions, prefix: "test")
+
+    execute "DROP SCHEMA test"
+  end
+end


### PR DESCRIPTION
It seems that `Ecto.Multi.update` does not infer the `schema_prefix` from the given changeset,
which results in an error when the `ProjectionVersion` has a custom `schema_prefix`.

This PR adds a test for the issue and passes the prefix to `Ecto.Multi.update`.